### PR TITLE
Use HTML (ASP.net) Syntax in .Master files

### DIFF
--- a/Syntaxes/HTML for ASP.net.plist
+++ b/Syntaxes/HTML for ASP.net.plist
@@ -8,6 +8,7 @@
 	<array>
 		<string>aspx</string>
 		<string>ascx</string>
+		<string>master</string>
 	</array>
 	<key>keyEquivalent</key>
 	<string>^~A</string>


### PR DESCRIPTION
ASP `.Master` files do not get highlighted by this syntax. This minor change enables it.
