### PR TITLE
Add some missing VB.NET keywords

### DIFF
--- a/Syntaxes/ASP VB.net.plist
+++ b/Syntaxes/ASP VB.net.plist
@@ -149,7 +149,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
+			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
 			<key>name</key>
 			<string>keyword.control.asp</string>
 		</dict>

--- a/Syntaxes/ASP VB.net.plist
+++ b/Syntaxes/ASP VB.net.plist
@@ -149,7 +149,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|Try|Catch|Finally|End Try|Using|End Using|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
+			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|Try|Catch|Finally|End Try|Using|End Using|With|End With|Namespace|End Namespace|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
 			<key>name</key>
 			<string>keyword.control.asp</string>
 		</dict>

--- a/Syntaxes/ASP VB.net.plist
+++ b/Syntaxes/ASP VB.net.plist
@@ -149,7 +149,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|Try|Catch|Finally|End Try|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
+			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|Try|Catch|Finally|End Try|Using|End Using|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
 			<key>name</key>
 			<string>keyword.control.asp</string>
 		</dict>

--- a/Syntaxes/ASP VB.net.plist
+++ b/Syntaxes/ASP VB.net.plist
@@ -155,7 +155,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(Mod|And|Not|Or|Xor|as)\b)</string>
+			<string>(?i:\b(Mod|And|AndAlso|Not|Or|OrElse|Xor|as)\b)</string>
 			<key>name</key>
 			<string>keyword.operator.asp</string>
 		</dict>

--- a/Syntaxes/ASP VB.net.plist
+++ b/Syntaxes/ASP VB.net.plist
@@ -149,7 +149,7 @@
 		</dict>
 		<dict>
 			<key>match</key>
-			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
+			<string>(?i:\b(If|Then|Else|ElseIf|Else If|End If|While|Wend|End While|For|To|Each|Case|Select|End Select|Return|Continue|Do|Until|Loop|Next|Try|Catch|Finally|End Try|With|End With|Exit Do|Exit For|Exit Function|Exit Property|Exit Sub|IIf)\b)</string>
 			<key>name</key>
 			<string>keyword.control.asp</string>
 		</dict>


### PR DESCRIPTION
VB.NET has `AndAlso` and `OrElse` as a short-circuiting alternative to `And` and `Or`.

Some other keywords have been missing.

References:
- https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/andalso-operator
- https://docs.microsoft.com/en-us/dotnet/visual-basic/language-reference/operators/orelse-operator

This PR also includes #9.